### PR TITLE
Add project README and runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# Semantic Merge Engine
+
+Semantic Merge Engine is a reference implementation of a structure-aware merge and diff toolchain for TypeScript projects. Instead of splicing text hunks, the engine builds a typed program model, extracts semantic operations, composes them deterministically, and materializes verified source files. It ships as a Python CLI backed by a Node.js worker and integrates with Git merge drivers for repo-wide workflows.
+
+## Table of contents
+- [Key capabilities](#key-capabilities)
+- [Repository layout](#repository-layout)
+- [Quick start](#quick-start)
+- [CLI usage](#cli-usage)
+- [Git integration](#git-integration)
+- [Configuration](#configuration)
+- [Development workflow](#development-workflow)
+- [Further reading](#further-reading)
+
+## Key capabilities
+- **Semantic diffing and merging for TypeScript.** The CLI exposes `semdiff` and `semmerge` commands that invoke a TypeScript-aware worker to generate and compose operation logs instead of text patches.
+- **Deterministic op composition and conflict detection.** Operation logs from both branches are sorted, chained, and merged with targeted `DivergentRename` conflicts when the same symbol is renamed differently.
+- **Best-effort application, formatting, and verification.** The engine replays supported operations onto the base tree, formats results via Prettier when available, and runs `tsc --noEmit`, gracefully skipping steps when the toolchain is missing.
+
+## Repository layout
+```text
+semantic_merge/
+├── semmerge/           # Python package hosting the CLI and orchestration logic
+├── workers/ts/         # Node-based worker that parses TypeScript and emits op logs
+├── scripts/            # Git merge driver wrapper
+├── tests/              # End-to-end smoke test exercising the CLI and driver
+├── architecture.md     # High-level architecture specification
+├── implementation.md   # Detailed implementation guide
+└── requirements.md     # Functional and non-functional requirements
+```
+
+## Quick start
+1. **Install prerequisites.** Ensure Python 3.10+, Node.js 18+, and Git 2.35+ are available, along with optional Java and .NET SDKs for future language backends.
+2. **Build the TypeScript worker.** Run `npm --prefix workers/ts install` followed by `npm --prefix workers/ts run build` to produce `workers/ts/dist/index.js`.
+3. **Install the Python package.** Execute `python -m pip install -e .` to install the CLI in editable mode for local development.
+4. **Run a smoke test.** Execute `bash tests/e2e_basic.sh` to compile the worker, install the CLI, and validate a simple rename-plus-move merge scenario.
+
+## CLI usage
+After installation, invoke commands via `python -m semmerge <command>` or the `semmerge` console script.
+
+### `semdiff <rev1> <rev2>`
+Checks out both revisions into temporary trees, asks the TypeScript worker for an op log, and prints either a human-readable listing or JSON when `--json-out` is provided.
+
+### `semmerge <base> <A> <B>`
+Performs a full semantic merge by:
+1. Checking out the three Git revisions to temporary directories.
+2. Requesting both op logs from the worker via `buildAndDiff`.
+3. Composing the logs into a deterministic operation sequence.
+4. Applying supported operations, formatting the result, and running `tsc --noEmit`.
+5. Writing the merged tree back into the working directory when `--inplace` is passed (Git merge driver mode).
+6. Persisting the per-branch op logs as Git notes for traceability.
+
+A non-zero exit status indicates conflicts (`1`) or type-check failures (`2`). Use the generated `.semmerge-conflicts.json` and CLI diagnostics to investigate.
+
+## Git integration
+The repository ships with `scripts/semmerge-driver.py`, a Git merge driver that orchestrates repo-level merges before handing the requested file back to Git. Enable it with:
+
+```bash
+# .gitconfig
+[merge "semmerge"]
+    name = Semantic merge engine
+    driver = python3 scripts/semmerge-driver.py %O %A %B
+
+# .gitattributes
+*.ts merge=semmerge
+```
+
+The driver locks merges per-repository to avoid concurrent runs, calls `python3 -m semmerge semmerge --inplace --git`, and copies resolved files into Git’s expected locations.
+
+## Configuration
+Project-level behaviour is controlled by an optional `.semmerge.toml` file. Core settings include deterministic seeds, memory caps, and preferred formatters. Language sections enable backends and supply project globbing and formatter commands, while the `ci` section toggles required verification steps. See `semmerge/config.py` for the schema.
+
+## Development workflow
+- **Logging.** Set `SEMMERGE_LOG=DEBUG` to increase verbosity when debugging CLI runs.
+- **Rebuilding the worker.** Re-run the npm install/build commands after making changes under `workers/ts/src/`.
+- **Tests.** The `tests/e2e_basic.sh` script covers the full Python/Node/Git pipeline; run it before publishing changes to verify end-to-end behaviour.
+- **Code references.** The TypeScript worker listens on stdin/stdout using JSON-RPC, and the Python bridge streams file snapshots to it. Conflict payloads, CRDT ordering, and op schemas are documented in the architecture and implementation guides for deeper dives.
+
+## Further reading
+- [architecture.md](architecture.md) — pipeline, data model, and backend expectations.
+- [implementation.md](implementation.md) — setup instructions and code walkthrough.
+- [requirements.md](requirements.md) — normative statements that govern scope and behaviour.

--- a/runbook.md
+++ b/runbook.md
@@ -1,0 +1,63 @@
+# Runbook: Semantic Merge Engine
+
+This runbook documents day-to-day operational procedures for the Semantic Merge Engine CLI and its Git integration. It is intended for developers and release engineers who maintain the toolchain and respond to support requests.
+
+## System overview
+- **Python orchestrator.** The `semmerge` package exposes the CLI (`semdiff`, `semmerge`) and coordinates tree checkout, op composition, application, formatting, and verification.
+- **TypeScript worker.** A Node.js process (`workers/ts/dist/index.js`) implements JSON-RPC methods that build lightweight program indexes, perform diffs, and lift them into operation logs consumed by Python.
+- **Git driver wrapper.** `scripts/semmerge-driver.py` locks concurrent executions, invokes `python3 -m semmerge semmerge --inplace --git`, and copies merged files back into Git’s temporary area.
+
+## Prerequisites and installation
+1. **Language runtimes.** Install Python 3.10+, Node.js 18+, and Git 2.35+. Optional Java 17+ and .NET 7+ runtimes prepare for additional backends.
+2. **Build the worker.** Run `npm --prefix workers/ts install` and `npm --prefix workers/ts run build` whenever TypeScript sources change. The Python bridge refuses to start the worker until `dist/index.js` exists.
+3. **Install the CLI.** Execute `python -m pip install -e .` from the repository root to expose the `semmerge` console script and module entry point.
+4. **Smoke-test the stack.** Invoke `bash tests/e2e_basic.sh` to reinstall dependencies, create a throwaway Git repo, configure the merge driver, and validate a rename-plus-move merge.
+
+## Routine operations
+### Running semantic merges manually
+1. Ensure the current Git repository has the desired commits available locally.
+2. Run `python -m semmerge semmerge <base> <A> <B> [--inplace]`.
+   - Without `--inplace` the merged tree remains in a temporary directory; use it for inspection.
+   - With `--inplace` the merge result overwrites the working tree (required for Git merge driver runs).
+3. Interpret exit codes:
+   - `0`: merge succeeded and, when applicable, type-check passed.
+   - `1`: semantic conflicts were detected. Inspect `.semmerge-conflicts.json` for payloads.
+   - `2`: TypeScript verification failed; CLI stderr contains compiler diagnostics.
+4. When conflicts arise, review the serialized ops in `.semmerge-conflicts.json` and resolve manually before re-running.
+
+### Using the Git merge driver
+1. Configure the repository:
+   - Add `[merge "semmerge"]` and `driver = python3 scripts/semmerge-driver.py %O %A %B` to `.git/config` or global config.
+   - Annotate target file globs (e.g., `*.ts`) with `merge=semmerge` inside `.gitattributes`.
+2. During `git merge`, the driver:
+   - Calculates the base commit via `git merge-base`.
+   - Serializes access with `.git/.semmerge.lock` to avoid concurrent merges.
+   - Calls the CLI with `--inplace --git`, allowing Git to read resolved files directly from the repository.
+3. If the driver exits with a non-zero status, Git reports the merge failure; inspect the CLI output and conflict artifacts as in manual runs.
+
+### Configuration management
+- Place `.semmerge.toml` at the repository root to override defaults.
+  - `[core]` controls deterministic seeds, memory caps, and formatter hints.
+  - `[languages.<name>]` toggles backends and defines project globbing plus formatter commands.
+  - `[ci]` enforces whether type-checking and test commands must succeed.
+- Run `python -m semmerge semmerge ...` from within the configured repository so relative formatter/test commands resolve correctly.
+
+### Observability and diagnostics
+- Set `SEMMERGE_LOG=DEBUG` to receive verbose logging from the Python orchestrator.
+- Conflict artifacts are written to `.semmerge-conflicts.json` in the current working directory when merges detect non-commuting ops.
+- Type-check diagnostics stream to stderr; Prettier output is suppressed unless the formatter fails.
+
+## Troubleshooting
+| Symptom | Likely cause | Mitigation |
+| --- | --- | --- |
+| `TypeScript worker not built` runtime error | `workers/ts/dist/index.js` missing | Re-run the npm install/build commands to regenerate the bundle. |
+| Merge exits with status 1 and `.semmerge-conflicts.json` contains `DivergentRename` entries | Both branches renamed the same symbol differently | Choose a preferred rename, apply it manually, and rerun the merge. |
+| Merge exits with status 2 and `tsc` errors | Type-check failed after applying ops | Fix the reported diagnostics or disable required checks via `.semmerge.toml` `[ci]` when appropriate. |
+| Prettier warnings in logs | Formatter returned a non-zero exit code | Investigate formatting errors; merging still produces syntactically valid output. |
+| `tsc` missing but merges succeed silently | TypeScript compiler is not installed | Install `typescript` globally or rely on the documented fallback when verification is optional. |
+
+## On-call checklist
+- Keep the worker bundle current by rebuilding after TypeScript source edits.
+- Ensure the CLI package is reinstalled (`pip install -e .`) after modifying Python modules.
+- Before cutting releases, run `bash tests/e2e_basic.sh` to cover the end-to-end pipeline.
+- Verify Git driver configuration in consuming repositories after updates to the wrapper script.


### PR DESCRIPTION
## Summary
- add a repository README describing the project, setup steps, CLI usage, git integration, and developer workflow references
- add an operational runbook covering prerequisites, manual merges, driver behaviour, configuration management, diagnostics, and troubleshooting guidance

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ced85af440832184733bbb5e8986c0