### PR TITLE
Fix Target materialization for move operations

### DIFF
--- a/semmerge/compose.py
+++ b/semmerge/compose.py
@@ -34,7 +34,7 @@ def compose_oplogs(delta_a: List[Op], delta_b: List[Op]) -> Tuple[List[Op], List
             new_addr = move_chain[symbol_id]
             if cloned.type == "moveDecl":
                 cloned.params["newAddress"] = new_addr
-            cloned.target = Target(symbol_id=symbol_id, addressId=new_addr)
+            cloned.target = Target(symbolId=symbol_id, addressId=new_addr)
         if symbol_id in rename_chain and cloned.type != "renameSymbol":
             cloned.params = {**cloned.params, "renameContext": rename_chain[symbol_id]}
         out.append(cloned)

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from semmerge.compose import compose_oplogs
+from semmerge.ops import Op, Target
+
+
+def test_compose_oplogs_handles_move_decl_without_errors():
+    move_op = Op.new(
+        op_type="moveDecl",
+        target=Target(symbolId="symbol-123", addressId="old-address"),
+        params={"newAddress": "new-address"},
+    )
+
+    composed_ops, conflicts = compose_oplogs([move_op], [])
+
+    assert conflicts == []
+    assert len(composed_ops) == 1
+    composed_move = composed_ops[0]
+    assert composed_move.type == "moveDecl"
+    assert composed_move.target.symbolId == "symbol-123"
+    assert composed_move.target.addressId == "new-address"
+    assert composed_move.params["newAddress"] == "new-address"


### PR DESCRIPTION
## Summary
- instantiate Target in compose.materialize with the dataclass field name
- add a regression test covering compose_oplogs with a moveDecl operation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d15e4af8b083218257df4f7dd6cc8f