### PR TITLE
Preinitialize merged tree before applying ops

### DIFF
--- a/semmerge/__main__.py
+++ b/semmerge/__main__.py
@@ -58,6 +58,7 @@ def semmerge(base: str, a: str, b: str, inplace: bool, git: bool) -> None:  # no
     base_tree = checkout_tree_to_temp(base)
     left_tree = checkout_tree_to_temp(a)
     right_tree = checkout_tree_to_temp(b)
+    merged_tree: pathlib.Path | None = None
 
     try:
         op_log_left, op_log_right, _symbol_maps = worker.build_and_diff(base_tree, left_tree, right_tree)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from semmerge import __main__ as cli
+
+
+class DummyWorker:
+    def __init__(self, close_calls: list[bool]) -> None:
+        self._close_calls = close_calls
+
+    def build_and_diff(self, base_tree, left_tree, right_tree):  # noqa: ANN001
+        return ["left"], ["right"], {}
+
+    def close(self) -> None:
+        self._close_calls.append(True)
+
+
+def test_semerge_propagates_exceptions_before_apply_ops(monkeypatch, tmp_path):
+    sentinel = RuntimeError("compose failure")
+    close_calls: list[bool] = []
+
+    monkeypatch.setattr(cli, "TSWorker", lambda: DummyWorker(close_calls))
+
+    def fake_checkout_tree_to_temp(rev: str) -> Path:
+        path = tmp_path / rev
+        path.mkdir(exist_ok=True)
+        return path
+
+    monkeypatch.setattr(cli, "checkout_tree_to_temp", fake_checkout_tree_to_temp)
+
+    def raise_on_compose(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise sentinel
+
+    monkeypatch.setattr(cli, "compose_oplogs", raise_on_compose)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        cli.semmerge.callback("base", "a", "b", inplace=False, git=False)
+
+    assert excinfo.value is sentinel
+    assert close_calls == [True]


### PR DESCRIPTION
## Summary
- preinitialize `merged_tree` before the merge try block so cleanup guards run safely
- add a regression test that forces a compose failure prior to `apply_ops` and asserts the original exception is raised

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d16378d868832181447e73ed088fce