### PR TITLE
Add tomli fallback for Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ requires-python = ">=3.10"
 dependencies = [
     "orjson>=3.9.0",
     "click>=8.1.7",
-    "typing-extensions>=4.12.2"
+    "typing-extensions>=4.12.2",
+    "tomli>=2.0.1; python_version < \"3.11\"",
 ]
 
 [project.scripts]

--- a/semmerge/config.py
+++ b/semmerge/config.py
@@ -3,8 +3,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable
+import importlib
+import importlib.util
 import pathlib
-import tomllib
+from types import ModuleType
+
+tomllib: ModuleType
+if importlib.util.find_spec("tomllib") is not None:  # pragma: no cover - depends on runtime Python version
+    tomllib = importlib.import_module("tomllib")
+else:  # pragma: no cover - exercised on Python < 3.11
+    tomllib = importlib.import_module("tomli")
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- detect the standard library tomllib module and fall back to tomli when it is unavailable
- add the tomli backport as a conditional dependency for Python < 3.11

## Testing
- pytest
- PYENV_VERSION=3.10.17 pyenv exec python -c "import semmerge.config"

------
https://chatgpt.com/codex/tasks/task_e_68d1697856448321a8d6045492266baf